### PR TITLE
Criar um servidor web

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,11 @@ dev: build
 stop:
 	docker-compose down
 
-test: dev migrate
+test: stop dev migrate
 	go test ./...
 
 migrate:
+	sleep 5
 	docker-compose exec postgres psql -U postgres -c "create database test"
 	docker-compose exec postgres psql -U postgres -c "create database development"
 	docker-compose exec postgres psql -U postgres -c "create database production"

--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ Apenas um sistema bastante inteligente para controlar o nosso dia-a-dia de traba
 
 ## Configuração
 
+Servidor WEB:
+```sh
+    # Postgres engine
+    $WEB_HOST=0.0.0.0
+    $WEB_PORT=3000
+```
+
 Banco de Dados:
 ```sh
     # Postgres engine

--- a/infrastructure/handlers/root_handler.go
+++ b/infrastructure/handlers/root_handler.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/magrathealabs/jarvis/infrastructure/routes"
 )
 
 // RootHandler struct
@@ -16,7 +17,7 @@ func NewRootHandler() Handler {
 
 // SetupRoutes on gin
 func (handler *RootHandler) SetupRoutes(engine *gin.Engine) {
-	engine.GET("/", handler.Index)
+	engine.GET(routes.Root, handler.Index)
 }
 
 // Index over / path

--- a/infrastructure/handlers/root_handler_test.go
+++ b/infrastructure/handlers/root_handler_test.go
@@ -1,0 +1,42 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/krakenlab/gspec"
+	"github.com/magrathealabs/jarvis/infrastructure/routes"
+)
+
+type RootHandlerSuite struct {
+	gspec.Suite
+
+	Engine   *gin.Engine
+	Recorder *httptest.ResponseRecorder
+}
+
+func (suite *RootHandlerSuite) SetupTest() {
+	suite.Engine = gin.Default()
+	suite.Recorder = httptest.NewRecorder()
+
+	NewRootHandler().SetupRoutes(suite.Engine)
+}
+
+func (suite *RootHandlerSuite) TestNewRootHandler() {
+	suite.NotNil(NewRootHandler())
+}
+
+func (suite *RootHandlerSuite) TestIndex() {
+	request, err := http.NewRequest(http.MethodGet, routes.Root, strings.NewReader(""))
+	suite.NoError(err)
+
+	suite.Engine.ServeHTTP(suite.Recorder, request)
+	suite.Equal(http.StatusOK, suite.Recorder.Code)
+}
+
+func TestRootHandlerSuite(t *testing.T) {
+	gspec.Run(t, new(RootHandlerSuite))
+}

--- a/infrastructure/routes/routes.go
+++ b/infrastructure/routes/routes.go
@@ -1,0 +1,6 @@
+package routes
+
+// Route paths
+var (
+	Root = "/"
+)

--- a/jarvis.go
+++ b/jarvis.go
@@ -1,7 +1,27 @@
 package main
 
-import "github.com/magrathealabs/jarvis/domain"
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/magrathealabs/jarvis/infrastructure/handlers"
+	"github.com/magrathealabs/jarvis/libs/env"
+)
+
+func usedHandlers() []handlers.Handler {
+	return []handlers.Handler{
+		handlers.NewRootHandler(),
+	}
+}
+
+func engine() *gin.Engine {
+	engine := gin.Default()
+
+	for _, handler := range usedHandlers() {
+		handler.SetupRoutes(engine)
+	}
+
+	return engine
+}
 
 func main() {
-	panic(domain.ErrNotImplemented)
+	panic(engine().Run(env.Server().Addr()))
 }

--- a/jarvis_test.go
+++ b/jarvis_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"testing"
 
 	"github.com/krakenlab/gspec"
@@ -11,6 +12,7 @@ type JarvisSuite struct {
 }
 
 func (suite *JarvisSuite) TestMain() {
+	os.Setenv("SERVER_PORT", "-1")
 	suite.Panics(main)
 }
 

--- a/libs/env/server_envs.go
+++ b/libs/env/server_envs.go
@@ -1,0 +1,26 @@
+package env
+
+import "fmt"
+
+// ServerEnvs store all env keys for Server configuration
+type ServerEnvs struct{}
+
+// Server envs
+func Server() *ServerEnvs {
+	return &ServerEnvs{}
+}
+
+// Host env
+func (env *ServerEnvs) Host() string {
+	return Env("SERVER_HOST", "0.0.0.0")
+}
+
+// Port env
+func (env *ServerEnvs) Port() string {
+	return Env("SERVER_PORT", "3000")
+}
+
+// Addr env
+func (env *ServerEnvs) Addr() string {
+	return fmt.Sprintf("%s:%s", env.Host(), env.Port())
+}

--- a/libs/env/server_envs_test.go
+++ b/libs/env/server_envs_test.go
@@ -1,0 +1,27 @@
+package env
+
+import (
+	"testing"
+
+	"github.com/krakenlab/gspec"
+)
+
+type ServerEnvsTest struct {
+	gspec.Suite
+}
+
+func (suite *ServerEnvsTest) TestHost() {
+	suite.Equal("0.0.0.0", Server().Host())
+}
+
+func (suite *ServerEnvsTest) TestPort() {
+	suite.Equal("3000", Server().Port())
+}
+
+func (suite *ServerEnvsTest) TestAddr() {
+	suite.Equal("0.0.0.0:3000", Server().Addr())
+}
+
+func TestServerEnvsTest(t *testing.T) {
+	gspec.Run(t, new(ServerEnvsTest))
+}


### PR DESCRIPTION
Este PR resolve #16 .

Não vejo a necessidade de criar um pacote `web` atualmente. Creio que futuramente seja legal extrair o `jarvis.go` para outro pacote, no caso de uma futura divisão em serviços.

A mágica agora acontece! :unicorn: 

`make up` e `wget localhost:3000` retorna `"OK!"` na tela inicial =D