### PR TITLE
Armazenar temperatura no graphite pela API

### DIFF
--- a/.requests.yaml
+++ b/.requests.yaml
@@ -1,0 +1,106 @@
+_type: export
+__export_format: 4
+__export_date: 2019-08-06T14:40:52.307Z
+__export_source: insomnia.desktop.app:v6.5.4
+resources:
+  - _id: req_6e996e2595d74efe952c9cf491575660
+    authentication: {}
+    body:
+      mimeType: application/json
+      text: |-
+        {
+          "recorded_at": "2019-08-06T11:15:00Z",
+          "recorded_by": "onion",
+          "temperature": 32,
+          "temperature_scale": "C",
+        	"relative_humidity": 0.5
+        }
+    created: 1565101251227
+    description: ""
+    headers:
+      - id: pair_a8d2cced176b47118075e6c2ea5cbdc2
+        name: Content-Type
+        value: application/json
+    isPrivate: false
+    metaSortKey: -1565101251227
+    method: POST
+    modified: 1565102167889
+    name: POST
+    parameters: []
+    parentId: fld_904ae18d269c4a5ebb3ef2fc8f7f468d
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingSendCookies: true
+    settingStoreCookies: true
+    url: "{{jarvis}}/api/v1/temperature"
+    _type: request
+  - _id: fld_904ae18d269c4a5ebb3ef2fc8f7f468d
+    created: 1565101236242
+    description: ""
+    environment: {}
+    environmentPropertyOrder: null
+    metaSortKey: -1565101236242
+    modified: 1565101236242
+    name: temperature
+    parentId: fld_2b4ba3bc8b7e4a3ead065d95597879f6
+    _type: request_group
+  - _id: fld_2b4ba3bc8b7e4a3ead065d95597879f6
+    created: 1565101219976
+    description: ""
+    environment: {}
+    environmentPropertyOrder: null
+    metaSortKey: -1565101219976
+    modified: 1565101219976
+    name: v1
+    parentId: fld_cf045976d2c74070a4c28af7b125dd02
+    _type: request_group
+  - _id: fld_cf045976d2c74070a4c28af7b125dd02
+    created: 1565101215405
+    description: ""
+    environment: {}
+    environmentPropertyOrder: null
+    metaSortKey: -1565101215405
+    modified: 1565101215405
+    name: api
+    parentId: wrk_b7b27496537e4318a5bf55642e54c776
+    _type: request_group
+  - _id: wrk_b7b27496537e4318a5bf55642e54c776
+    created: 1565101088613
+    description: ""
+    modified: 1565101088613
+    name: Jarvis
+    parentId: null
+    _type: workspace
+  - _id: env_4bc6e1a970469c8de5b6e84374eea7aa161b37fb
+    color: null
+    created: 1565101088688
+    data: {}
+    dataPropertyOrder: null
+    isPrivate: false
+    metaSortKey: 1565101088689
+    modified: 1565101088688
+    name: Base Environment
+    parentId: wrk_b7b27496537e4318a5bf55642e54c776
+    _type: environment
+  - _id: jar_4bc6e1a970469c8de5b6e84374eea7aa161b37fb
+    cookies: []
+    created: 1565101088697
+    modified: 1565101088697
+    name: Default Jar
+    parentId: wrk_b7b27496537e4318a5bf55642e54c776
+    _type: cookie_jar
+  - _id: env_0806991288724a228eab451a181bc1b9
+    color: "#00ff15"
+    created: 1565101124601
+    data:
+      jarvis: localhost:3000
+    dataPropertyOrder:
+      "&":
+        - jarvis
+    isPrivate: false
+    metaSortKey: 1565101124601
+    modified: 1565101200795
+    name: Dev
+    parentId: env_4bc6e1a970469c8de5b6e84374eea7aa161b37fb
+    _type: environment

--- a/domain/errors.go
+++ b/domain/errors.go
@@ -1,8 +1,0 @@
-package domain
-
-import "errors"
-
-// All errors in jarvin
-var (
-	ErrNotImplemented = errors.New("Not implemented error")
-)

--- a/domain/exceptions/exceptions.go
+++ b/domain/exceptions/exceptions.go
@@ -1,0 +1,43 @@
+package exceptions
+
+import (
+	"errors"
+	"fmt"
+)
+
+func init() {
+	ErrorRecordedInMeyNotBeInTheFuture = mayNotBeInTheFuture("recorded_in")
+	ErrorTemperatureScaleMstBeCFK = scaleMustBeCFK("temperature")
+	ErrorUnfortunatelyWeHeventMetTemperaturesFromOtherPlanetsYet = unfortunatelyWeHeventMetTemperaturesFromOtherPlanetsYet()
+	ErrorPercentageMustBeBetween0and1 = mustBeBetweenXandY("percentage", "0.0", "1.0")
+	ErrorRecordedByNeedsToBePresent = needsToBePresent("recorded_by")
+}
+
+// Model error
+var (
+	ErrorRecordedInMeyNotBeInTheFuture                           error
+	ErrorTemperatureScaleMstBeCFK                                error
+	ErrorUnfortunatelyWeHeventMetTemperaturesFromOtherPlanetsYet error
+	ErrorPercentageMustBeBetween0and1                            error
+	ErrorRecordedByNeedsToBePresent                              error
+)
+
+func mayNotBeInTheFuture(field string) error {
+	return fmt.Errorf("%s may not be in the future", field)
+}
+
+func scaleMustBeCFK(field string) error {
+	return fmt.Errorf("%s scale must be C|F|K", field)
+}
+
+func unfortunatelyWeHeventMetTemperaturesFromOtherPlanetsYet() error {
+	return errors.New("unfortunately we haven't met temperatures from other planets yet")
+}
+
+func mustBeBetweenXandY(field, x, y string) error {
+	return fmt.Errorf("%s must be between %s and %s", field, x, y)
+}
+
+func needsToBePresent(field string) error {
+	return fmt.Errorf("%s needs to be present", field)
+}

--- a/domain/models/base.go
+++ b/domain/models/base.go
@@ -13,11 +13,29 @@ type Base struct {
 	CreatedAt time.Time  `json:"created_at"`
 	UpdatedAt time.Time  `json:"updated_at"`
 	DeletedAt *time.Time `sql:"index" json:"deleted_at"`
+
+	Errors []error `json:"errors"`
 }
 
 // NewBase constructor
 func NewBase() *Base {
 	return &Base{}
+}
+
+// AppendError in model
+func (base *Base) AppendError(errs ...error) {
+	base.Errors = append(base.Errors, errs...)
+}
+
+// Valid verify errors list
+func (base *Base) Valid() bool {
+	for _, err := range base.Errors {
+		if err != nil {
+			return false
+		}
+	}
+
+	return true
 }
 
 // ToJSON marshal

--- a/domain/models/base.go
+++ b/domain/models/base.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"encoding/json"
+	"strings"
 	"time"
 
 	"github.com/krakenlab/ternary"
@@ -43,4 +44,13 @@ func (base *Base) ToJSON() string {
 	data, err := json.Marshal(base)
 	ternary.Func(err == nil, func() {}, func() { panic(err) })()
 	return string(data)
+}
+
+func (base *Base) clearMetricTag(tag string) string {
+	tag = strings.Replace(tag, "/", "_", -1)
+	tag = strings.TrimPrefix(tag, "_")
+	tag = strings.TrimSuffix(tag, "_")
+	tag = ternary.String(tag == "", "root", tag)
+
+	return tag
 }

--- a/domain/models/base_test.go
+++ b/domain/models/base_test.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/krakenlab/gspec"
@@ -12,6 +13,15 @@ type BaseSuite struct {
 
 func (suite *BaseSuite) TestNewBase() {
 	suite.NotNil(NewBase())
+}
+
+func (suite *BaseSuite) TestValid() {
+	base := NewBase()
+
+	suite.True(base.Valid())
+
+	base.AppendError(errors.New("testing"))
+	suite.False(base.Valid())
 }
 
 func (suite *BaseSuite) TestToJSON() {

--- a/domain/models/end_point_runtime.go
+++ b/domain/models/end_point_runtime.go
@@ -3,7 +3,6 @@ package models
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/krakenlab/ternary"
 )
@@ -22,23 +21,18 @@ func NewEndpointRuntime(value int64, route string) *EndpointRuntime {
 }
 
 // ToJSON marshal
-func (EndpointRuntime *EndpointRuntime) ToJSON() string {
-	data, err := json.Marshal(EndpointRuntime)
+func (endpointRuntime *EndpointRuntime) ToJSON() string {
+	data, err := json.Marshal(endpointRuntime)
 	ternary.Func(err == nil, func() {}, func() { panic(err) })()
 	return string(data)
 }
 
 // MetricValue transformation
-func (EndpointRuntime *EndpointRuntime) MetricValue() string {
-	return fmt.Sprintf("%d", EndpointRuntime.Value)
+func (endpointRuntime *EndpointRuntime) MetricValue() string {
+	return fmt.Sprintf("%d", endpointRuntime.Value)
 }
 
 // MetricTag route transformation
-func (EndpointRuntime *EndpointRuntime) MetricTag() string {
-	metricRoute := strings.Replace(EndpointRuntime.Route, "/", "_", -1)
-	metricRoute = strings.TrimPrefix(metricRoute, "_")
-	metricRoute = strings.TrimSuffix(metricRoute, "_")
-	metricRoute = ternary.String(metricRoute == "", "root", metricRoute)
-
-	return fmt.Sprintf("end_point_runtime.%s", metricRoute)
+func (endpointRuntime *EndpointRuntime) MetricTag() string {
+	return fmt.Sprintf("end_point_runtime.%s", endpointRuntime.clearMetricTag(endpointRuntime.Route))
 }

--- a/domain/models/end_point_runtime_test.go
+++ b/domain/models/end_point_runtime_test.go
@@ -15,8 +15,8 @@ func (suite *EndpointRuntimeSuite) TestNewEndpointRuntime() {
 }
 
 func (suite *EndpointRuntimeSuite) TestToJSON() {
-	EndpointRuntime := NewEndpointRuntime(0, "testing")
-	json := EndpointRuntime.ToJSON()
+	endpointRuntime := NewEndpointRuntime(0, "testing")
+	json := endpointRuntime.ToJSON()
 
 	suite.Contains(json, "id")
 	suite.Contains(json, "created_at")
@@ -31,16 +31,16 @@ func (suite *EndpointRuntimeSuite) TestToJSON() {
 }
 
 func (suite *EndpointRuntimeSuite) TestMetricValue() {
-	EndpointRuntime := NewEndpointRuntime(0, "/route/api/testing")
-	suite.Equal("0", EndpointRuntime.MetricValue())
+	endpointRuntime := NewEndpointRuntime(0, "/route/api/testing")
+	suite.Equal("0", endpointRuntime.MetricValue())
 }
 
 func (suite *EndpointRuntimeSuite) TestMetricTag() {
-	EndpointRuntime := NewEndpointRuntime(0, "/route/api/testing/")
-	suite.Equal("end_point_runtime.route_api_testing", EndpointRuntime.MetricTag())
+	endpointRuntime := NewEndpointRuntime(0, "/route/api/testing/")
+	suite.Equal("end_point_runtime.route_api_testing", endpointRuntime.MetricTag())
 
-	EndpointRuntime = NewEndpointRuntime(0, "/")
-	suite.Equal("end_point_runtime.root", EndpointRuntime.MetricTag())
+	endpointRuntime = NewEndpointRuntime(0, "/")
+	suite.Equal("end_point_runtime.root", endpointRuntime.MetricTag())
 
 }
 

--- a/domain/models/temperature.go
+++ b/domain/models/temperature.go
@@ -20,8 +20,8 @@ type Temperature struct {
 }
 
 // NewTemperature constructor
-func NewTemperature(temperature float32, temperatureScale enums.TemperatureScale) *Temperature {
-	return &Temperature{Temperature: temperature, TemperatureScale: temperatureScale}
+func NewTemperature() *Temperature {
+	return &Temperature{Temperature: 0, TemperatureScale: enums.CelsiusTemperaureScale}
 }
 
 // ToJSON marshal

--- a/domain/models/temperature.go
+++ b/domain/models/temperature.go
@@ -2,11 +2,11 @@ package models
 
 import (
 	"encoding/json"
-	"errors"
 	"time"
 
 	"github.com/krakenlab/ternary"
 	"github.com/magrathealabs/jarvis/domain/enums"
+	"github.com/magrathealabs/jarvis/domain/exceptions"
 	"github.com/magrathealabs/jarvis/domain/validators"
 )
 
@@ -48,7 +48,7 @@ func (temperature *Temperature) verifyRecordedAt() {
 	recordedAtValidator := validators.NewTimeValidator(temperature.RecordedAt)
 
 	if recordedAtValidator.InTheFuture() {
-		temperature.AppendError(errors.New("recorded_in may not be in the future"))
+		temperature.AppendError(exceptions.ErrorRecordedInMeyNotBeInTheFuture)
 	}
 }
 
@@ -56,7 +56,7 @@ func (temperature *Temperature) verifyTemperatureScale() {
 	temperatureScaleValidator := validators.NewTemperatureScaleValidator(temperature.TemperatureScale)
 
 	if temperatureScaleValidator.InvalidEnum() {
-		temperature.AppendError(errors.New("temperature scale must be C|F|K"))
+		temperature.AppendError(exceptions.ErrorTemperatureScaleMstBeCFK)
 	}
 }
 
@@ -64,7 +64,7 @@ func (temperature *Temperature) verifyTemperature() {
 	temperatureValidator := validators.NewFloat32Validator(temperature.Temperature)
 
 	if !temperatureValidator.InBetween(-1000, 1000) {
-		temperature.AppendError(errors.New("unfortunately we haven't met temperatures from other planets yet"))
+		temperature.AppendError(exceptions.ErrorUnfortunatelyWeHeventMetTemperaturesFromOtherPlanetsYet)
 	}
 }
 
@@ -72,7 +72,7 @@ func (temperature *Temperature) verifyRelativeHumidity() {
 	relativeHumidityValidator := validators.NewFloat32Validator(temperature.RelativeHumidity)
 
 	if !relativeHumidityValidator.InBetween(0, 1) {
-		temperature.AppendError(errors.New("percentage must be between 0 and 1"))
+		temperature.AppendError(exceptions.ErrorPercentageMustBeBetween0and1)
 	}
 }
 
@@ -80,6 +80,6 @@ func (temperature *Temperature) verifyRecordedBy() {
 	recordedByValidator := validators.NewStringValidator(temperature.RecordedBy)
 
 	if recordedByValidator.Nil() {
-		temperature.AppendError(errors.New("recorded_by needs to be present"))
+		temperature.AppendError(exceptions.ErrorRecordedByNeedsToBePresent)
 	}
 }

--- a/domain/models/temperature.go
+++ b/domain/models/temperature.go
@@ -2,10 +2,12 @@ package models
 
 import (
 	"encoding/json"
+	"errors"
 	"time"
 
 	"github.com/krakenlab/ternary"
 	"github.com/magrathealabs/jarvis/domain/enums"
+	"github.com/magrathealabs/jarvis/domain/validators"
 )
 
 // Temperature struct
@@ -29,4 +31,35 @@ func (temperature *Temperature) ToJSON() string {
 	data, err := json.Marshal(temperature)
 	ternary.Func(err == nil, func() {}, func() { panic(err) })()
 	return string(data)
+}
+
+// Valid model
+func (temperature *Temperature) Valid() bool {
+	recordedAtValidator := validators.NewTimeValidator(temperature.RecordedAt)
+	temperatureScaleValidator := validators.NewTemperatureScaleValidator(temperature.TemperatureScale)
+	temperatureValidator := validators.NewFloat32Validator(temperature.Temperature)
+	relativeHumidityValidator := validators.NewFloat32Validator(temperature.RelativeHumidity)
+	recordedByValidator := validators.NewStringValidator(temperature.RecordedBy)
+
+	if recordedAtValidator.InTheFuture() {
+		temperature.AppendError(errors.New("recorded_in may not be in the future"))
+	}
+
+	if temperatureScaleValidator.InvalidEnum() {
+		temperature.AppendError(errors.New("temperature scale must be C|F|K"))
+	}
+
+	if !temperatureValidator.InBetween(-1000, 1000) {
+		temperature.AppendError(errors.New("unfortunately we haven't met temperatures from other planets yet"))
+	}
+
+	if !relativeHumidityValidator.InBetween(0, 1) {
+		temperature.AppendError(errors.New("percentage must be between 0 and 1"))
+	}
+
+	if recordedByValidator.Nil() {
+		temperature.AppendError(errors.New("recorded_by needs to be present"))
+	}
+
+	return temperature.Base.Valid()
 }

--- a/domain/models/temperature.go
+++ b/domain/models/temperature.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"encoding/json"
+	"time"
 
 	"github.com/krakenlab/ternary"
 	"github.com/magrathealabs/jarvis/domain/enums"
@@ -11,14 +12,16 @@ import (
 type Temperature struct {
 	Base
 
-	RecordedBy string                 `json:"recorded_by"`
-	Value      float32                `json:"value"`
-	Scale      enums.TemperatureScale `json:"scale"`
+	RecordedBy       string                 `json:"recorded_by"`
+	RecordedAt       time.Time              `json:"recorded_at"`
+	Temperature      float32                `json:"temperature"`
+	TemperatureScale enums.TemperatureScale `json:"temperature_scale"`
+	RelativeHumidity float32                `json:"relative_humidity"`
 }
 
 // NewTemperature constructor
-func NewTemperature(value float32, scale enums.TemperatureScale) *Temperature {
-	return &Temperature{Value: value, Scale: scale}
+func NewTemperature(temperature float32, temperatureScale enums.TemperatureScale) *Temperature {
+	return &Temperature{Temperature: temperature, TemperatureScale: temperatureScale}
 }
 
 // ToJSON marshal

--- a/domain/models/temperature.go
+++ b/domain/models/temperature.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/krakenlab/ternary"
@@ -31,6 +32,16 @@ func (temperature *Temperature) ToJSON() string {
 	data, err := json.Marshal(temperature)
 	ternary.Func(err == nil, func() {}, func() { panic(err) })()
 	return string(data)
+}
+
+// MetricValue to store in MetricRepository
+func (temperature *Temperature) MetricValue() string {
+	return fmt.Sprintf("%f", temperature.Temperature)
+}
+
+// MetricTag to store in MetricRepository
+func (temperature *Temperature) MetricTag() string {
+	return fmt.Sprintf("temperature.%s.%s", temperature.TemperatureScale, temperature.RecordedBy)
 }
 
 // Valid model

--- a/domain/models/temperature.go
+++ b/domain/models/temperature.go
@@ -34,14 +34,24 @@ func (temperature *Temperature) ToJSON() string {
 	return string(data)
 }
 
-// MetricValue to store in MetricRepository
-func (temperature *Temperature) MetricValue() string {
+// TemperatureMetricValue to store in MetricRepository
+func (temperature *Temperature) TemperatureMetricValue() string {
 	return fmt.Sprintf("%f", temperature.Temperature)
 }
 
-// MetricTag to store in MetricRepository
-func (temperature *Temperature) MetricTag() string {
+// RelativeHumidityMetricValue to store in MetricRepository
+func (temperature *Temperature) RelativeHumidityMetricValue() string {
+	return fmt.Sprintf("%f", temperature.RelativeHumidity)
+}
+
+// TemperatureMetricTag to store in MetricRepository
+func (temperature *Temperature) TemperatureMetricTag() string {
 	return fmt.Sprintf("temperature.%s.%s", temperature.TemperatureScale, temperature.RecordedBy)
+}
+
+// RelativeHumidityMetricTag to store in MetricRepository
+func (temperature *Temperature) RelativeHumidityMetricTag() string {
+	return fmt.Sprintf("relative_humidity.%s", temperature.RecordedBy)
 }
 
 // Valid model

--- a/domain/models/temperature.go
+++ b/domain/models/temperature.go
@@ -35,31 +35,51 @@ func (temperature *Temperature) ToJSON() string {
 
 // Valid model
 func (temperature *Temperature) Valid() bool {
+	temperature.verifyRecordedAt()
+	temperature.verifyTemperatureScale()
+	temperature.verifyTemperature()
+	temperature.verifyRelativeHumidity()
+	temperature.verifyRecordedBy()
+
+	return temperature.Base.Valid()
+}
+
+func (temperature *Temperature) verifyRecordedAt() {
 	recordedAtValidator := validators.NewTimeValidator(temperature.RecordedAt)
-	temperatureScaleValidator := validators.NewTemperatureScaleValidator(temperature.TemperatureScale)
-	temperatureValidator := validators.NewFloat32Validator(temperature.Temperature)
-	relativeHumidityValidator := validators.NewFloat32Validator(temperature.RelativeHumidity)
-	recordedByValidator := validators.NewStringValidator(temperature.RecordedBy)
 
 	if recordedAtValidator.InTheFuture() {
 		temperature.AppendError(errors.New("recorded_in may not be in the future"))
 	}
+}
+
+func (temperature *Temperature) verifyTemperatureScale() {
+	temperatureScaleValidator := validators.NewTemperatureScaleValidator(temperature.TemperatureScale)
 
 	if temperatureScaleValidator.InvalidEnum() {
 		temperature.AppendError(errors.New("temperature scale must be C|F|K"))
 	}
+}
+
+func (temperature *Temperature) verifyTemperature() {
+	temperatureValidator := validators.NewFloat32Validator(temperature.Temperature)
 
 	if !temperatureValidator.InBetween(-1000, 1000) {
 		temperature.AppendError(errors.New("unfortunately we haven't met temperatures from other planets yet"))
 	}
+}
+
+func (temperature *Temperature) verifyRelativeHumidity() {
+	relativeHumidityValidator := validators.NewFloat32Validator(temperature.RelativeHumidity)
 
 	if !relativeHumidityValidator.InBetween(0, 1) {
 		temperature.AppendError(errors.New("percentage must be between 0 and 1"))
 	}
+}
+
+func (temperature *Temperature) verifyRecordedBy() {
+	recordedByValidator := validators.NewStringValidator(temperature.RecordedBy)
 
 	if recordedByValidator.Nil() {
 		temperature.AppendError(errors.New("recorded_by needs to be present"))
 	}
-
-	return temperature.Base.Valid()
 }

--- a/domain/models/temperature_test.go
+++ b/domain/models/temperature_test.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"testing"
+	"time"
 
 	"github.com/magrathealabs/jarvis/domain/enums"
 
@@ -39,6 +40,19 @@ func (suite *TemperatureSuite) TestToJSON() {
 
 	temperature.TemperatureScale = enums.FahrenheitTemperaureScale
 	suite.Contains(temperature.ToJSON(), enums.FahrenheitTemperaureScale)
+}
+
+func (suite *TemperatureSuite) TestValid() {
+	temperature := NewTemperature()
+
+	temperature.RecordedAt = time.Now().Add(time.Hour)
+	temperature.RecordedBy = ""
+	temperature.Temperature = -2000
+	temperature.TemperatureScale = enums.TemperatureScale("Miojo scale")
+	temperature.RelativeHumidity = 1.2
+
+	suite.False(temperature.Valid())
+	suite.Equal(5, len(temperature.Errors))
 }
 
 func TestTemperatureSuite(t *testing.T) {

--- a/domain/models/temperature_test.go
+++ b/domain/models/temperature_test.go
@@ -25,8 +25,11 @@ func (suite *TemperatureSuite) TestToJSON() {
 	suite.Contains(json, "deleted_at")
 	suite.Contains(json, "updated_at")
 
-	suite.Contains(json, "value")
-	suite.Contains(json, "scale")
+	suite.Contains(json, "temperature")
+	suite.Contains(json, "temperature_scale")
+	suite.Contains(json, "relative_humidity")
+	suite.Contains(json, "recorded_by")
+	suite.Contains(json, "recorded_at")
 
 	suite.Contains(json, "0")
 	suite.Contains(json, enums.CelsiusTemperaureScale)

--- a/domain/models/temperature_test.go
+++ b/domain/models/temperature_test.go
@@ -42,6 +42,26 @@ func (suite *TemperatureSuite) TestToJSON() {
 	suite.Contains(temperature.ToJSON(), enums.FahrenheitTemperaureScale)
 }
 
+func (suite *TemperatureSuite) TestMatricTag() {
+	temperature := NewTemperature()
+
+	temperature.RecordedAt = time.Now().Add(time.Hour)
+	temperature.RecordedBy = "beacon"
+	temperature.Temperature = 15
+
+	suite.Equal("temperature.C.beacon", temperature.MetricTag())
+}
+
+func (suite *TemperatureSuite) TestMetricValue() {
+	temperature := NewTemperature()
+
+	temperature.RecordedAt = time.Now().Add(time.Hour)
+	temperature.RecordedBy = "beacon"
+	temperature.Temperature = 15.05
+
+	suite.Equal("15.050000", temperature.MetricValue())
+}
+
 func (suite *TemperatureSuite) TestValid() {
 	temperature := NewTemperature()
 

--- a/domain/models/temperature_test.go
+++ b/domain/models/temperature_test.go
@@ -13,11 +13,11 @@ type TemperatureSuite struct {
 }
 
 func (suite *TemperatureSuite) TestNewTemperature() {
-	suite.NotNil(NewTemperature(0, enums.CelsiusTemperaureScale))
+	suite.NotNil(NewTemperature())
 }
 
 func (suite *TemperatureSuite) TestToJSON() {
-	temperature := NewTemperature(0, enums.CelsiusTemperaureScale)
+	temperature := NewTemperature()
 	json := temperature.ToJSON()
 
 	suite.Contains(json, "id")
@@ -34,10 +34,10 @@ func (suite *TemperatureSuite) TestToJSON() {
 	suite.Contains(json, "0")
 	suite.Contains(json, enums.CelsiusTemperaureScale)
 
-	temperature = NewTemperature(0, enums.KelvinTemperaureScale)
+	temperature.TemperatureScale = enums.KelvinTemperaureScale
 	suite.Contains(temperature.ToJSON(), enums.KelvinTemperaureScale)
 
-	temperature = NewTemperature(0, enums.FahrenheitTemperaureScale)
+	temperature.TemperatureScale = enums.FahrenheitTemperaureScale
 	suite.Contains(temperature.ToJSON(), enums.FahrenheitTemperaureScale)
 }
 

--- a/domain/models/temperature_test.go
+++ b/domain/models/temperature_test.go
@@ -42,24 +42,44 @@ func (suite *TemperatureSuite) TestToJSON() {
 	suite.Contains(temperature.ToJSON(), enums.FahrenheitTemperaureScale)
 }
 
-func (suite *TemperatureSuite) TestMatricTag() {
+func (suite *TemperatureSuite) TestTemperatureMetricTag() {
 	temperature := NewTemperature()
 
 	temperature.RecordedAt = time.Now().Add(time.Hour)
 	temperature.RecordedBy = "beacon"
 	temperature.Temperature = 15
 
-	suite.Equal("temperature.C.beacon", temperature.MetricTag())
+	suite.Equal("temperature.C.beacon", temperature.TemperatureMetricTag())
 }
 
-func (suite *TemperatureSuite) TestMetricValue() {
+func (suite *TemperatureSuite) TestRelativeHumidityMetricTag() {
+	temperature := NewTemperature()
+
+	temperature.RecordedAt = time.Now().Add(time.Hour)
+	temperature.RecordedBy = "beacon"
+	temperature.Temperature = 15
+
+	suite.Equal("relative_humidity.beacon", temperature.RelativeHumidityMetricTag())
+}
+
+func (suite *TemperatureSuite) TestTemperatureMetricValue() {
 	temperature := NewTemperature()
 
 	temperature.RecordedAt = time.Now().Add(time.Hour)
 	temperature.RecordedBy = "beacon"
 	temperature.Temperature = 15.05
 
-	suite.Equal("15.050000", temperature.MetricValue())
+	suite.Equal("15.050000", temperature.TemperatureMetricValue())
+}
+
+func (suite *TemperatureSuite) TestRelativeHumidityMetricValue() {
+	temperature := NewTemperature()
+
+	temperature.RecordedAt = time.Now().Add(time.Hour)
+	temperature.RecordedBy = "beacon"
+	temperature.RelativeHumidity = 0.05
+
+	suite.Equal("0.050000", temperature.RelativeHumidityMetricValue())
 }
 
 func (suite *TemperatureSuite) TestValid() {

--- a/domain/repositories/metric_repository.go
+++ b/domain/repositories/metric_repository.go
@@ -1,6 +1,9 @@
 package repositories
 
+import "time"
+
 // MetricRepository interface
 type MetricRepository interface {
 	InsertMetric(tag string, value string) error
+	InsertMetricAt(tag string, value string, at time.Time) error
 }

--- a/domain/services/forms/stores_temperature_form.go
+++ b/domain/services/forms/stores_temperature_form.go
@@ -13,6 +13,7 @@ type StoresTemperatureForm struct {
 	RecordedAt       time.Time              `json:"recorded_at"`
 	RecordedBy       string                 `json:"recorded_by"`
 	Temperature      float32                `json:"temperature"`
+	RelativeHumidity float32                `json:"relative_humidity"`
 	TemperatureScale enums.TemperatureScale `json:"temperature_scale"`
 }
 
@@ -29,6 +30,7 @@ func (form *StoresTemperatureForm) BuildTemperature() *models.Temperature {
 	temperature.RecordedBy = form.RecordedBy
 	temperature.Temperature = form.Temperature
 	temperature.TemperatureScale = form.TemperatureScale
+	temperature.RelativeHumidity = form.RelativeHumidity
 
 	return temperature
 }

--- a/domain/services/forms/stores_temperature_form.go
+++ b/domain/services/forms/stores_temperature_form.go
@@ -1,0 +1,34 @@
+package forms
+
+import (
+	"time"
+
+	"github.com/magrathealabs/jarvis/domain/enums"
+
+	"github.com/magrathealabs/jarvis/domain/models"
+)
+
+// StoresTemperatureForm bind temperature model infos to store in metric repostory
+type StoresTemperatureForm struct {
+	RecordedAt       time.Time              `json:"recorded_at"`
+	RecordedBy       string                 `json:"recorded_by"`
+	Temperature      float32                `json:"temperature"`
+	TemperatureScale enums.TemperatureScale `json:"temperature_scale"`
+}
+
+// NewStoresTemperature constructor
+func NewStoresTemperature() *StoresTemperatureForm {
+	return &StoresTemperatureForm{}
+}
+
+// BuildTemperature based in this form
+func (form *StoresTemperatureForm) BuildTemperature() *models.Temperature {
+	temperature := models.NewTemperature()
+
+	temperature.RecordedAt = form.RecordedAt
+	temperature.RecordedBy = form.RecordedBy
+	temperature.Temperature = form.Temperature
+	temperature.TemperatureScale = form.TemperatureScale
+
+	return temperature
+}

--- a/domain/services/forms/stores_temperature_form_test.go
+++ b/domain/services/forms/stores_temperature_form_test.go
@@ -23,6 +23,7 @@ func (suite *StoresTemperatureFormSuite) TestBuildTemperature() {
 	form.RecordedAt = time.Now()
 	form.Temperature = -5
 	form.TemperatureScale = enums.CelsiusTemperaureScale
+	form.RelativeHumidity = 0.5
 
 	temperature := form.BuildTemperature()
 
@@ -30,6 +31,7 @@ func (suite *StoresTemperatureFormSuite) TestBuildTemperature() {
 	suite.Equal(form.RecordedAt, temperature.RecordedAt)
 	suite.Equal(form.Temperature, temperature.Temperature)
 	suite.Equal(form.TemperatureScale, temperature.TemperatureScale)
+	suite.Equal(form.RelativeHumidity, temperature.RelativeHumidity)
 }
 
 func TestStoresTemperatureFormSuite(t *testing.T) {

--- a/domain/services/forms/stores_temperature_form_test.go
+++ b/domain/services/forms/stores_temperature_form_test.go
@@ -1,0 +1,37 @@
+package forms
+
+import (
+	"testing"
+	"time"
+
+	"github.com/magrathealabs/jarvis/domain/enums"
+
+	"github.com/krakenlab/gspec"
+)
+
+type StoresTemperatureFormSuite struct {
+	gspec.Suite
+}
+
+func (suite *StoresTemperatureFormSuite) TestNewStoresTemperatureForm() {
+	suite.NotNil(NewStoresTemperature())
+}
+
+func (suite *StoresTemperatureFormSuite) TestBuildTemperature() {
+	form := NewStoresTemperature()
+	form.RecordedBy = "device"
+	form.RecordedAt = time.Now()
+	form.Temperature = -5
+	form.TemperatureScale = enums.CelsiusTemperaureScale
+
+	temperature := form.BuildTemperature()
+
+	suite.Equal(form.RecordedBy, temperature.RecordedBy)
+	suite.Equal(form.RecordedAt, temperature.RecordedAt)
+	suite.Equal(form.Temperature, temperature.Temperature)
+	suite.Equal(form.TemperatureScale, temperature.TemperatureScale)
+}
+
+func TestStoresTemperatureFormSuite(t *testing.T) {
+	gspec.Run(t, new(StoresTemperatureFormSuite))
+}

--- a/domain/services/mock_test.go
+++ b/domain/services/mock_test.go
@@ -1,8 +1,11 @@
 package services
 
+import "time"
+
 // MetricRepositoryMock struct
 type MetricRepositoryMock struct {
-	InsertMetricReturn error
+	InsertMetricReturn   error
+	InsertMetricAtReturn error
 }
 
 func NewMetricRepositoryMock() *MetricRepositoryMock {
@@ -10,5 +13,9 @@ func NewMetricRepositoryMock() *MetricRepositoryMock {
 }
 
 func (mock *MetricRepositoryMock) InsertMetric(tag string, value string) error {
+	return mock.InsertMetricReturn
+}
+
+func (mock *MetricRepositoryMock) InsertMetricAt(tag string, value string, at time.Time) error {
 	return mock.InsertMetricReturn
 }

--- a/domain/services/responses/stores_temperature_response.go
+++ b/domain/services/responses/stores_temperature_response.go
@@ -1,0 +1,16 @@
+package responses
+
+import (
+	"github.com/magrathealabs/jarvis/domain/models"
+)
+
+// StoresTemperatureResponse output
+type StoresTemperatureResponse struct {
+	Temperature *models.Temperature `json:"temperature"`
+	Stored      bool
+}
+
+// NewStoresTemperature Response
+func NewStoresTemperature() *StoresTemperatureResponse {
+	return &StoresTemperatureResponse{}
+}

--- a/domain/services/responses/stores_temperature_response_test.go
+++ b/domain/services/responses/stores_temperature_response_test.go
@@ -1,0 +1,27 @@
+package responses
+
+import (
+	"testing"
+
+	"github.com/krakenlab/gspec"
+)
+
+type StoresTemperatureResponseSuite struct {
+	gspec.Suite
+}
+
+func (suite *StoresTemperatureResponseSuite) TestNewStoresTemperatureResponse() {
+	suite.NotNil(NewStoresTemperature())
+}
+
+func (suite *StoresTemperatureResponseSuite) TestStored() {
+	suite.False(NewStoresTemperature().Stored)
+}
+
+func (suite *StoresTemperatureResponseSuite) TestTemperature() {
+	suite.Nil(NewStoresTemperature().Temperature)
+}
+
+func TestStoresTemperatureResponseSuite(t *testing.T) {
+	gspec.Run(t, new(StoresTemperatureResponseSuite))
+}

--- a/domain/services/temperature_service.go
+++ b/domain/services/temperature_service.go
@@ -1,0 +1,21 @@
+package services
+
+import (
+	"github.com/magrathealabs/jarvis/domain/repositories"
+	"github.com/magrathealabs/jarvis/domain/services/forms"
+)
+
+// TemperatureService handles temperature metrics
+type TemperatureService struct {
+	MetricRepository repositories.MetricRepository
+}
+
+// NewTemperatureService constructor
+func NewTemperatureService(metricRepository repositories.MetricRepository) *TemperatureService {
+	return &TemperatureService{MetricRepository: metricRepository}
+}
+
+// StoresTemperature in metric repository
+func (service *TemperatureService) StoresTemperature(form *forms.StoresTemperatureForm) {
+	_ = form.BuildTemperature()
+}

--- a/domain/services/temperature_service.go
+++ b/domain/services/temperature_service.go
@@ -23,16 +23,28 @@ func (service *TemperatureService) StoresTemperature(form *forms.StoresTemperatu
 
 	response.Temperature = form.BuildTemperature()
 	if response.Temperature.Valid() {
-		response.Stored = service.insertTemperature(response.Temperature)
+		response.Stored = service.insertTemperatureAndRelativeHumidity(response.Temperature)
 	}
 
 	return response
 }
 
+func (service *TemperatureService) insertTemperatureAndRelativeHumidity(temperature *models.Temperature) bool {
+	return service.insertTemperature(temperature) && service.insertRelativeHumidity(temperature)
+}
+
 func (service *TemperatureService) insertTemperature(temperature *models.Temperature) bool {
 	return service.MetricRepository.InsertMetricAt(
-		temperature.MetricTag(),
-		temperature.MetricValue(),
+		temperature.TemperatureMetricTag(),
+		temperature.TemperatureMetricValue(),
+		temperature.RecordedAt,
+	) == nil
+}
+
+func (service *TemperatureService) insertRelativeHumidity(temperature *models.Temperature) bool {
+	return service.MetricRepository.InsertMetricAt(
+		temperature.RelativeHumidityMetricTag(),
+		temperature.RelativeHumidityMetricValue(),
 		temperature.RecordedAt,
 	) == nil
 }

--- a/domain/services/temperature_service.go
+++ b/domain/services/temperature_service.go
@@ -1,8 +1,10 @@
 package services
 
 import (
+	"github.com/magrathealabs/jarvis/domain/models"
 	"github.com/magrathealabs/jarvis/domain/repositories"
 	"github.com/magrathealabs/jarvis/domain/services/forms"
+	"github.com/magrathealabs/jarvis/domain/services/responses"
 )
 
 // TemperatureService handles temperature metrics
@@ -16,6 +18,21 @@ func NewTemperatureService(metricRepository repositories.MetricRepository) *Temp
 }
 
 // StoresTemperature in metric repository
-func (service *TemperatureService) StoresTemperature(form *forms.StoresTemperatureForm) {
-	_ = form.BuildTemperature()
+func (service *TemperatureService) StoresTemperature(form *forms.StoresTemperatureForm) *responses.StoresTemperatureResponse {
+	response := responses.NewStoresTemperature()
+
+	response.Temperature = form.BuildTemperature()
+	if response.Temperature.Valid() {
+		response.Stored = service.insertTemperature(response.Temperature)
+	}
+
+	return response
+}
+
+func (service *TemperatureService) insertTemperature(temperature *models.Temperature) bool {
+	return service.MetricRepository.InsertMetricAt(
+		temperature.MetricTag(),
+		temperature.MetricValue(),
+		temperature.RecordedAt,
+	) == nil
 }

--- a/domain/services/temperature_service_test.go
+++ b/domain/services/temperature_service_test.go
@@ -1,0 +1,45 @@
+package services
+
+import (
+	"testing"
+	"time"
+
+	"github.com/magrathealabs/jarvis/domain/enums"
+	"github.com/magrathealabs/jarvis/domain/services/forms"
+
+	"github.com/krakenlab/gspec"
+)
+
+type TemperatureServiceSuite struct {
+	gspec.Suite
+}
+
+func (suite *TemperatureServiceSuite) TestNewTemperatureService() {
+	suite.NotNil(NewTemperatureService(NewMetricRepositoryMock()))
+}
+
+func (suite *TemperatureServiceSuite) TestStoresTemperature() {
+	metricRepository := NewMetricRepositoryMock()
+	metricRepository.InsertMetricAtReturn = nil
+
+	service := NewTemperatureService(metricRepository)
+
+	form := forms.NewStoresTemperature()
+	form.RecordedAt = time.Now()
+	form.RecordedBy = "jarvis_beacon"
+	form.Temperature = 45
+	form.TemperatureScale = enums.CelsiusTemperaureScale
+
+	response := service.StoresTemperature(form)
+
+	suite.Equal(response.Temperature.RecordedAt, form.RecordedAt)
+	suite.Equal(response.Temperature.RecordedBy, form.RecordedBy)
+	suite.Equal(response.Temperature.Temperature, form.Temperature)
+	suite.Equal(response.Temperature.TemperatureScale, form.TemperatureScale)
+
+	suite.True(response.Stored)
+}
+
+func TestTemperatureServiceSuite(t *testing.T) {
+	gspec.Run(t, new(TemperatureServiceSuite))
+}

--- a/domain/validators/float32_validator.go
+++ b/domain/validators/float32_validator.go
@@ -1,0 +1,16 @@
+package validators
+
+// Float32Validator struct
+type Float32Validator struct {
+	Field float32
+}
+
+// NewFloat32Validator constructor
+func NewFloat32Validator(field float32) *Float32Validator {
+	return &Float32Validator{Field: field}
+}
+
+// InBetween two values
+func (validator *Float32Validator) InBetween(min, max float32) bool {
+	return validator.Field >= min && validator.Field <= max
+}

--- a/domain/validators/float32_validator_test.go
+++ b/domain/validators/float32_validator_test.go
@@ -1,0 +1,26 @@
+package validators
+
+import (
+	"testing"
+
+	"github.com/krakenlab/gspec"
+)
+
+type Float32ValidatorSuite struct {
+	gspec.Suite
+}
+
+func (suite *Float32ValidatorSuite) TestNewFloat32Validator() {
+	suite.NotNil(NewFloat32Validator(0))
+}
+
+func (suite *Float32ValidatorSuite) TestInBetween() {
+	suite.True(NewFloat32Validator(0).InBetween(-100, 100))
+	suite.False(NewFloat32Validator(-200).InBetween(-100, 100))
+	suite.False(NewFloat32Validator(200).InBetween(-100, 100))
+
+}
+
+func TestFloat32ValidatorSuite(t *testing.T) {
+	gspec.Run(t, new(Float32ValidatorSuite))
+}

--- a/domain/validators/string_validator.go
+++ b/domain/validators/string_validator.go
@@ -1,0 +1,21 @@
+package validators
+
+// StringValidator struct
+type StringValidator struct {
+	Field string
+}
+
+// NewStringValidator constructor
+func NewStringValidator(field string) *StringValidator {
+	return &StringValidator{Field: field}
+}
+
+// Nil value
+func (validator *StringValidator) Nil() bool {
+	return validator.Field == ""
+}
+
+// NotNil value
+func (validator *StringValidator) NotNil() bool {
+	return !validator.Nil()
+}

--- a/domain/validators/string_validator_test.go
+++ b/domain/validators/string_validator_test.go
@@ -1,0 +1,29 @@
+package validators
+
+import (
+	"testing"
+
+	"github.com/krakenlab/gspec"
+)
+
+type StringValidatorSuite struct {
+	gspec.Suite
+}
+
+func (suite *StringValidatorSuite) TestStringValidator() {
+	suite.NotNil(NewStringValidator(""))
+}
+
+func (suite *StringValidatorSuite) TestNil() {
+	suite.True(NewStringValidator("").Nil())
+	suite.False(NewStringValidator("Miojo").Nil())
+}
+
+func (suite *StringValidatorSuite) TestNotNil() {
+	suite.False(NewStringValidator("").NotNil())
+	suite.True(NewStringValidator("Miojo").NotNil())
+}
+
+func TestStringValidatorSuite(t *testing.T) {
+	gspec.Run(t, new(StringValidatorSuite))
+}

--- a/domain/validators/temperature_scale_validator.go
+++ b/domain/validators/temperature_scale_validator.go
@@ -1,0 +1,27 @@
+package validators
+
+import (
+	"github.com/magrathealabs/jarvis/domain/enums"
+)
+
+// TemperatureScaleValidator verify time structs
+type TemperatureScaleValidator struct {
+	Field enums.TemperatureScale
+}
+
+// NewTemperatureScaleValidator constructor
+func NewTemperatureScaleValidator(field enums.TemperatureScale) *TemperatureScaleValidator {
+	return &TemperatureScaleValidator{Field: field}
+}
+
+// ValidEnum verify the domain of enums.TemperatureScale
+func (validator *TemperatureScaleValidator) ValidEnum() bool {
+	return validator.Field == enums.CelsiusTemperaureScale ||
+		validator.Field == enums.KelvinTemperaureScale ||
+		validator.Field == enums.FahrenheitTemperaureScale
+}
+
+// InvalidEnum verify the domain of enums.TemperatureScale
+func (validator *TemperatureScaleValidator) InvalidEnum() bool {
+	return !validator.ValidEnum()
+}

--- a/domain/validators/temperature_scale_validator_test.go
+++ b/domain/validators/temperature_scale_validator_test.go
@@ -1,0 +1,39 @@
+package validators
+
+import (
+	"testing"
+
+	"github.com/magrathealabs/jarvis/domain/enums"
+
+	"github.com/krakenlab/gspec"
+)
+
+type TemperatureScaleValidatorSuite struct {
+	gspec.Suite
+}
+
+func (suite *TemperatureScaleValidatorSuite) TestNewTemperatureScaleValidator() {
+	suite.NotNil(NewTemperatureScaleValidator(enums.CelsiusTemperaureScale))
+}
+
+func (suite *TemperatureScaleValidatorSuite) TestValidEnum() {
+	suite.True(NewTemperatureScaleValidator(enums.CelsiusTemperaureScale).ValidEnum())
+	suite.True(NewTemperatureScaleValidator(enums.KelvinTemperaureScale).ValidEnum())
+	suite.True(NewTemperatureScaleValidator(enums.FahrenheitTemperaureScale).ValidEnum())
+
+	// Miojo's temperature scale
+	suite.False(NewTemperatureScaleValidator(enums.TemperatureScale("M")).ValidEnum())
+}
+
+func (suite *TemperatureScaleValidatorSuite) TestInvalidEnum() {
+	suite.False(NewTemperatureScaleValidator(enums.CelsiusTemperaureScale).InvalidEnum())
+	suite.False(NewTemperatureScaleValidator(enums.KelvinTemperaureScale).InvalidEnum())
+	suite.False(NewTemperatureScaleValidator(enums.FahrenheitTemperaureScale).InvalidEnum())
+
+	// Miojo's temperature scale
+	suite.True(NewTemperatureScaleValidator(enums.TemperatureScale("M")).InvalidEnum())
+}
+
+func TestTemperatureScaleValidatorSuite(t *testing.T) {
+	gspec.Run(t, new(TemperatureScaleValidatorSuite))
+}

--- a/domain/validators/time_validator.go
+++ b/domain/validators/time_validator.go
@@ -16,3 +16,8 @@ func NewTimeValidator(time time.Time) *TimeValidator {
 func (validator *TimeValidator) NotInTheFuture() bool {
 	return validator.Field.Before(time.Now())
 }
+
+// InTheFuture verify
+func (validator *TimeValidator) InTheFuture() bool {
+	return !validator.NotInTheFuture()
+}

--- a/domain/validators/time_validator.go
+++ b/domain/validators/time_validator.go
@@ -1,0 +1,18 @@
+package validators
+
+import "time"
+
+// TimeValidator verify time structs
+type TimeValidator struct {
+	Field time.Time
+}
+
+// NewTimeValidator constructor
+func NewTimeValidator(time time.Time) *TimeValidator {
+	return &TimeValidator{Field: time}
+}
+
+// NotInTheFuture verify
+func (validator *TimeValidator) NotInTheFuture() bool {
+	return validator.Field.Before(time.Now())
+}

--- a/domain/validators/time_validator_test.go
+++ b/domain/validators/time_validator_test.go
@@ -1,0 +1,25 @@
+package validators
+
+import (
+	"testing"
+	"time"
+
+	"github.com/krakenlab/gspec"
+)
+
+type TimeValidatorSuite struct {
+	gspec.Suite
+}
+
+func (suite *TimeValidatorSuite) TestNewTemperature() {
+	suite.NotNil(NewTimeValidator(time.Now()))
+}
+
+func (suite *TimeValidatorSuite) TestNotInTheFuture() {
+	suite.True(NewTimeValidator(time.Now()).NotInTheFuture())
+	suite.False(NewTimeValidator(time.Now().Add(time.Hour)).NotInTheFuture())
+}
+
+func TestTimeValidatorSuite(t *testing.T) {
+	gspec.Run(t, new(TimeValidatorSuite))
+}

--- a/domain/validators/time_validator_test.go
+++ b/domain/validators/time_validator_test.go
@@ -20,6 +20,11 @@ func (suite *TimeValidatorSuite) TestNotInTheFuture() {
 	suite.False(NewTimeValidator(time.Now().Add(time.Hour)).NotInTheFuture())
 }
 
+func (suite *TimeValidatorSuite) TestInTheFuture() {
+	suite.False(NewTimeValidator(time.Now()).InTheFuture())
+	suite.True(NewTimeValidator(time.Now().Add(time.Hour)).InTheFuture())
+}
+
 func TestTimeValidatorSuite(t *testing.T) {
 	gspec.Run(t, new(TimeValidatorSuite))
 }

--- a/domain/validators/time_validator_test.go
+++ b/domain/validators/time_validator_test.go
@@ -11,7 +11,7 @@ type TimeValidatorSuite struct {
 	gspec.Suite
 }
 
-func (suite *TimeValidatorSuite) TestNewTemperature() {
+func (suite *TimeValidatorSuite) TestNewTimeValidator() {
 	suite.NotNil(NewTimeValidator(time.Now()))
 }
 

--- a/infrastructure/datastore/metric_repository.go
+++ b/infrastructure/datastore/metric_repository.go
@@ -1,6 +1,8 @@
 package datastore
 
 import (
+	"time"
+
 	"github.com/krakenlab/ternary"
 	"github.com/magrathealabs/jarvis/domain/repositories"
 	"github.com/magrathealabs/jarvis/libs/env"
@@ -28,5 +30,11 @@ func NewMetricRepositoryFromEnv() repositories.MetricRepository {
 
 // InsertMetric into graphite
 func (repository *MetricRepository) InsertMetric(tag string, value string) error {
-	return repository.conn.SimpleSend(tag, value)
+	return repository.InsertMetricAt(tag, value, time.Now())
+}
+
+// InsertMetricAt custom time into graphite
+func (repository *MetricRepository) InsertMetricAt(tag string, value string, at time.Time) error {
+	metric := graphite.NewMetric(tag, value, at.UTC().Unix())
+	return repository.conn.SendMetric(metric)
 }

--- a/infrastructure/datastore/metric_repository_test.go
+++ b/infrastructure/datastore/metric_repository_test.go
@@ -2,6 +2,7 @@ package datastore
 
 import (
 	"testing"
+	"time"
 
 	"github.com/krakenlab/gspec"
 )
@@ -12,6 +13,8 @@ type MetricRepositorySuite struct {
 
 func (suite *MetricRepositorySuite) TestNewMetricRepository() {
 	suite.NotNil(NewMetricRepository("localhost", 2003))
+
+	suite.Panics(func() { NewMetricRepository("localhost", -1) })
 }
 
 func (suite *MetricRepositorySuite) TestNewMetricRepositoryFromEnv() {
@@ -20,6 +23,12 @@ func (suite *MetricRepositorySuite) TestNewMetricRepositoryFromEnv() {
 
 func (suite *MetricRepositorySuite) TestInsertMetric() {
 	err := NewMetricRepositoryFromEnv().InsertMetric("testin", "0")
+
+	suite.NoError(err)
+}
+
+func (suite *MetricRepositorySuite) TestInsertMetricAt() {
+	err := NewMetricRepositoryFromEnv().InsertMetricAt("testin", "0", time.Now())
 
 	suite.NoError(err)
 }

--- a/infrastructure/handlers/api/v1/temperature_handler.go
+++ b/infrastructure/handlers/api/v1/temperature_handler.go
@@ -3,6 +3,10 @@ package v1
 import (
 	"net/http"
 
+	"github.com/magrathealabs/jarvis/domain/services"
+
+	"github.com/magrathealabs/jarvis/domain/services/forms"
+
 	"github.com/gin-gonic/gin"
 	"github.com/magrathealabs/jarvis/domain/repositories"
 	"github.com/magrathealabs/jarvis/infrastructure/routes"
@@ -23,10 +27,18 @@ func NewTemperatureHandler(metricRepository repositories.MetricRepository) handl
 
 // SetupRoutes on gin
 func (handler *TemperatureHandler) SetupRoutes(engine *gin.Engine) {
-	engine.GET(routes.APIV1Temperature, handler.Index)
+	engine.POST(routes.APIV1Temperature, handler.Create)
 }
 
-// Index over /api/v1/temperature path
-func (handler *TemperatureHandler) Index(c *gin.Context) {
-	c.String(http.StatusOK, "OK!")
+// Create over /api/v1/temperature path (Post)
+func (handler *TemperatureHandler) Create(c *gin.Context) {
+	form := forms.NewStoresTemperature()
+
+	if c.BindJSON(form) == nil {
+		service := services.NewTemperatureService(handler.MetricRepository)
+		c.JSON(http.StatusOK, service.StoresTemperature(form))
+		return
+	}
+
+	c.JSON(http.StatusInternalServerError, form)
 }

--- a/infrastructure/handlers/api/v1/temperature_handler.go
+++ b/infrastructure/handlers/api/v1/temperature_handler.go
@@ -37,8 +37,5 @@ func (handler *TemperatureHandler) Create(c *gin.Context) {
 	if c.BindJSON(form) == nil {
 		service := services.NewTemperatureService(handler.MetricRepository)
 		c.JSON(http.StatusOK, service.StoresTemperature(form))
-		return
 	}
-
-	c.JSON(http.StatusInternalServerError, form)
 }

--- a/infrastructure/handlers/root_handler.go
+++ b/infrastructure/handlers/root_handler.go
@@ -1,12 +1,9 @@
 package handlers
 
 import (
-	"net/http"
-
 	"github.com/gin-gonic/gin"
 	"github.com/magrathealabs/jarvis/domain/repositories"
 	"github.com/magrathealabs/jarvis/infrastructure/handlers/api"
-	"github.com/magrathealabs/jarvis/infrastructure/routes"
 	"github.com/magrathealabs/jarvis/libs/handler"
 )
 
@@ -24,12 +21,5 @@ func NewRootHandler(metricRepository repositories.MetricRepository) handler.Hand
 
 // SetupRoutes on gin
 func (handler *RootHandler) SetupRoutes(engine *gin.Engine) {
-	engine.GET(routes.Root, handler.Index)
-
 	api.NewHandler(handler.MetricRepository).SetupRoutes(engine)
-}
-
-// Index over / path
-func (handler *RootHandler) Index(c *gin.Context) {
-	c.String(http.StatusOK, "OK!")
 }

--- a/infrastructure/handlers/root_handler_test.go
+++ b/infrastructure/handlers/root_handler_test.go
@@ -1,15 +1,12 @@
 package handlers
 
 import (
-	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
 	"github.com/krakenlab/gspec"
 	"github.com/magrathealabs/jarvis/infrastructure/datastore"
-	"github.com/magrathealabs/jarvis/infrastructure/routes"
 )
 
 type RootHandlerSuite struct {
@@ -28,14 +25,6 @@ func (suite *RootHandlerSuite) SetupTest() {
 
 func (suite *RootHandlerSuite) TestNewRootHandler() {
 	suite.NotNil(NewRootHandler(datastore.NewMetricRepositoryFromEnv()))
-}
-
-func (suite *RootHandlerSuite) TestIndex() {
-	request, err := http.NewRequest(http.MethodGet, routes.Root, strings.NewReader(""))
-	suite.NoError(err)
-
-	suite.Engine.ServeHTTP(suite.Recorder, request)
-	suite.Equal(http.StatusOK, suite.Recorder.Code)
 }
 
 func TestRootHandlerSuite(t *testing.T) {


### PR DESCRIPTION
Este PR armazena a temperatura no graphite pela rota `POST /api/v1/temperature`.

Você deve repassar o form do domínio.

resolve #27 
resolve #26 